### PR TITLE
Require 'pathname'

### DIFF
--- a/lib/kitno.rb
+++ b/lib/kitno.rb
@@ -3,6 +3,7 @@ require 'kitno/cli'
 
 require 'find'
 require 'fileutils'
+require 'pathname'
 
 module Kitno
   class KillingInTheNamespaceOf


### PR DESCRIPTION
`Pathname` needs to be required (not sure if this is a Ruby version thing? wasn't failing specs)